### PR TITLE
Update 0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Welcome to Vishroom Powder repository.
- Vishroom Powder is a small add-on for [Thaumcraft 6](https://www.curseforge.com/minecraft/mc-mods/thaumcraft) [Minecraft](https://minecraft.net/) 1.2.2 [Forge](https://files.minecraftforge.net/)
+Vishroom Powder is a small add-on for [Thaumcraft 6](https://www.curseforge.com/minecraft/mc-mods/thaumcraft)
 
 # What is Vishroom Powder?
- Vishroom Powder is a small add-on for Thaumcraft 6, adding Vishroom Powder that, when consumed, affects rendering and adds screen-space effects.
+Vishroom Powder is a small add-on for Thaumcraft 6, adding Vishroom Powder that, when consumed, affects rendering and adds screen-space effects.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 
-version = '1.12.2-0.7.2'
+version = '1.12.2-0.7.3'
 group = 'pupkin.vishroom_powder' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'vishroom_powder'
 

--- a/src/main/java/pupkin/mod/potion/ItemVishroomPowder.java
+++ b/src/main/java/pupkin/mod/potion/ItemVishroomPowder.java
@@ -17,13 +17,13 @@ import javax.annotation.Nonnull;
 
 public class ItemVishroomPowder extends ItemFood implements IHasModel
 {
-
 	public ItemVishroomPowder(String name, CreativeTabs tab, int amount, float saturation, boolean isWolfFood)
 	{
 		super(amount, saturation, isWolfFood);
 		setUnlocalizedName(name);
 		setRegistryName(name);
 		setCreativeTab(tab);
+		setMaxStackSize(Integer.MAX_VALUE);
 
 		ItemInit.ITEMS.add(this);
 	}
@@ -44,7 +44,7 @@ public class ItemVishroomPowder extends ItemFood implements IHasModel
 	private void applyCustomEffect(EntityLivingBase entity)
 	{
 		if (!entity.world.isRemote) {
-			entity.addPotionEffect(new PotionEffect(YellowTintEffect.YELLOW_TINT, 200, 0));
+			entity.addPotionEffect(new PotionEffect(YellowTintEffect.YELLOW_TINT, 1200, 0));
 		}
 	}
 
@@ -52,6 +52,7 @@ public class ItemVishroomPowder extends ItemFood implements IHasModel
 	@Override
 	public ActionResult<ItemStack> onItemRightClick(@Nonnull World worldIn, @Nonnull EntityPlayer playerIn, @Nonnull EnumHand handIn)
 	{
+		playerIn.setActiveHand(handIn);
 		return super.onItemRightClick(worldIn, playerIn, handIn);
 	}
 }

--- a/src/main/resources/assets/vishroom_powder/lang/de_de.lang
+++ b/src/main/resources/assets/vishroom_powder/lang/de_de.lang
@@ -1,0 +1,1 @@
+item.vishroom_powder.name=Vispilz Pulver

--- a/src/main/resources/assets/vishroom_powder/lang/fr_fr.lang
+++ b/src/main/resources/assets/vishroom_powder/lang/fr_fr.lang
@@ -1,0 +1,1 @@
+item.vishroom_powder.name=Poudre de Champivis

--- a/src/main/resources/assets/vishroom_powder/lang/ja_jp.lang
+++ b/src/main/resources/assets/vishroom_powder/lang/ja_jp.lang
@@ -1,0 +1,1 @@
+item.vishroom_powder.name=ヴィシュルーム パウダー

--- a/src/main/resources/assets/vishroom_powder/lang/ko_kr.lang
+++ b/src/main/resources/assets/vishroom_powder/lang/ko_kr.lang
@@ -1,0 +1,1 @@
+item.vishroom_powder.name=비쉬룸 파우더

--- a/src/main/resources/assets/vishroom_powder/lang/nl_nl.lang
+++ b/src/main/resources/assets/vishroom_powder/lang/nl_nl.lang
@@ -1,0 +1,1 @@
+item.vishroom_powder.name=Bovis Poeder

--- a/src/main/resources/assets/vishroom_powder/lang/zh_cn.lang
+++ b/src/main/resources/assets/vishroom_powder/lang/zh_cn.lang
@@ -1,0 +1,1 @@
+item.vishroom_powder.name=纤毛菇粉

--- a/src/main/resources/assets/vishroom_powder/lang/zh_tw.lang
+++ b/src/main/resources/assets/vishroom_powder/lang/zh_tw.lang
@@ -1,0 +1,1 @@
+item.vishroom_powder.name=魔蕈粉

--- a/src/main/resources/assets/vishroom_powder/recipes/powder/vishroom_powder.json
+++ b/src/main/resources/assets/vishroom_powder/recipes/powder/vishroom_powder.json
@@ -3,12 +3,6 @@
   "ingredients": [
     {
       "item": "thaumcraft:vishroom"
-    },
-    {
-      "item": "minecraft:bowl"
-    },
-    {
-      "item": "minecraft:flint"
     }
   ],
   "result": {


### PR DESCRIPTION
- Vishroom powder can now be eaten even when not hungry;
- Removed bowl and flint from vishroom powder recipe, as before the player was apparently "eating" them;
- Yellow tint potion effect now granted for 1200 ticks when consuming vishroom powder;
- Added de_de, fe_fe, ja_jp, ko_kr, nl_nl, zn_cn, zn_tw translations;
- Removed unnecessary information from readme.